### PR TITLE
AP以外の消費アイテム対応

### DIFF
--- a/info_trouble.py
+++ b/info_trouble.py
@@ -104,7 +104,7 @@ def makeDiffStr() -> int:
         str_diff = troubleDiff(old, new)
 
         if len(str_diff) > 0:
-            name = titles[i] + ":bug:"
+            name = titles[i].replace("■", ":bug:") + ":bug:"
             value = "```" + str_diff + "```"
             fields.append({"name": name, "value": value})
     if len(fields) > 0:


### PR DESCRIPTION
1. クエストの消費単位がAP決め打ちだったのを修正
2. 交換アイテム投稿がテキストファイルになる判定を修正
3. 不具合表示の微修正